### PR TITLE
Feature/remove neat bourbon

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.1",
   "description": "Theme toolchain used for Drupal projects running the Deck subtheme.",
   "author": "Matt Chapman <chapabu101@gmail.com>",
+  "repository": "https://github.com/inviqa/deck-task-registry",
   "engines": {
     "node": ">=6.0.0"
   },
@@ -21,8 +22,6 @@
   "license": "MIT",
   "dependencies": {
     "autoprefixer": "^6.4.0",
-    "bourbon": "^4.2.7",
-    "bourbon-neat": "^1.8.0",
     "del": "^2.2.1",
     "glob": "^7.1.1",
     "gulp": "github:gulpjs/gulp#4.0",

--- a/src/post-install/files/config.example.js
+++ b/src/post-install/files/config.example.js
@@ -11,7 +11,8 @@ module.exports = {
         "browserSupport": [
           "last 2 versions"
         ],
-        "stylelint": {}
+        "stylelint": {},
+        "nodeSassConf": {}
       },
       "js": {
         "src": "assets/src/js",

--- a/src/styles/buildStyles.js
+++ b/src/styles/buildStyles.js
@@ -11,12 +11,7 @@ const autoprefixer = require('autoprefixer');
 function buildStyles(conf) {
 
     // Config that gets passed to node-sass.
-    const sassConfig = {
-      includePaths: [
-        require('bourbon').includePaths,
-        require('bourbon-neat').includePaths
-      ]
-    };
+    const sassConfig = conf.themeConfig.sass.nodeSassConf || {};
 
     // If we're in production mode, then compress the output CSS.
     if (conf.productionMode) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,16 +343,6 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bourbon-neat@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/bourbon-neat/-/bourbon-neat-1.8.0.tgz#2ffd6dbfee45db5140f2fff280163302c73e7335"
-  dependencies:
-    node-sass "^3.4"
-
-bourbon@^4.2.7:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/bourbon/-/bourbon-4.3.2.tgz#857582bc516243864d6c8db23d5eeea0343db4a6"
-
 boxen@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-0.6.0.tgz#8364d4248ac34ff0ef1b2f2bf49a6c60ce0d81b6"
@@ -3161,7 +3151,7 @@ node-pre-gyp@^0.6.29:
     tar "~2.2.1"
     tar-pack "~3.3.0"
 
-node-sass@^3.4, node-sass@^3.4.2:
+node-sass@^3.4.2:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-3.13.1.tgz#7240fbbff2396304b4223527ed3020589c004fc2"
   dependencies:


### PR DESCRIPTION
Fixes #21 

Removed `includePaths` setting and offsets control to the user. Now, someone will just need to add a `nodeSassConf` key, who's value will be passed directly to `gulp-sass`/`node-sass`.

i.e.

```js
nodeSassConf: {
  includePaths: {
    require('bourbon').includePaths
  }
}
```